### PR TITLE
Show how to detach fork from upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Magisk on WSA (with Google Apps)
 
-:warning: For fork developers: Please detach the fork from [upstream](https://github.com/LSPosed/MagiskOnWSALocal) before building with Actions, Github will count the forked Actions usage to the upstream repository, which means if a forked repository abuses Actions, the repository that gets disabled will be upstream. We are not against forks, but please detach them from our repository. If you do not make changes one day after receiving the detachment request, our organization will ban you.
+:warning: For fork developers: Please [use the GitHub Support virtual assistant chatbot](https://support.github.com/request?q=Attach%2C+detach+or+reroute+forks#:~:text=our%20virtual%20assistant%20can%20help%20with%20detaching%2Funforking%20a%20repository) to detach your fork from [upstream](https://github.com/LSPosed/MagiskOnWSALocal) before building with GitHub Actions, as GitHub will count your forked GitHub Actions usage agasint this upstream repository GitHub Actions usage, which causes this upstream repository gets disabled by GitHub employee(s) due to numerous forks building GitHub Actions, and counting the forks' GitHub Action builds agasint this upstream repository GitHub Actions usage as abusing GitHub Actions.
+We are not against forks, but please detach them from our repository. If you do not make changes one day after receiving the detachment request, our organization will ban you.
+
+How to detach your fork from this upstream repository (a visual guide): ![How to detach form using GitHub Support virtual assistant chatbot](https://user-images.githubusercontent.com/96967473/194208623-194e5926-feb9-4172-b57f-a82179245d02.png)
+
 
 ## Support for generating from these systems
 


### PR DESCRIPTION
I'm rewriting README.md to drive the point that is imperative to detach fork from upstream and inserting clickable links that shows the virtual assistant chatbot link to follow.

Checklist

- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Have tested the modifications
